### PR TITLE
Fixed issue with renewal of loans

### DIFF
--- a/lib/AlmaClient/AlmaClient.class.php
+++ b/lib/AlmaClient/AlmaClient.class.php
@@ -533,11 +533,13 @@ class AlmaClient {
           //If message is "isRenewedToday" we assumme that the renewal is successful.
           //Even if this is not the case any error in the current renewal is irrelevant
           //as the loan has previously been renewed so don't report it as such
-          if ($message == 'isRenewedToday') {
+          if ($message == 'isRenewedToday' || $renewable == 'yes') {
             $reservations[$id] = TRUE; 
           } elseif ($message == 'maxNofRenewals') {
-            $reservations[$id] = t('Maximum number of renewals reached'); 
-          } elseif (!$renewable) {
+            $reservations[$id] = t('Maximum number of renewals reached');
+          } elseif ($message == 'copyIsReserved') {
+            $reservations[$id] = t('The material is reserved by another loaner');
+          } else {
             $reservations[$id] = t('Unable to renew material');
           }
         }


### PR DESCRIPTION
When loaners renew a loan the first time in a new load period. The system will return a "Not renewed" message, but the material may have been renewed. This pull request fixes this.
