### PR TITLE
Removed auth check from add payment callback.

### DIFF
--- a/alma_user/alma_user.module
+++ b/alma_user/alma_user.module
@@ -241,15 +241,13 @@ function alma_user_ding_debt_list_form_pay($form, &$form_state) {
 }
 
 /**
+ * Register a transaction as paid.
  *
+ * Called by the dibs module when transaction is completed.
+ *
+ * @param array $transatction
+ *   Transaction array as provided by DIBS.
  */
 function alma_user_debt_dibs_add_payment($transaction) {
-  global $user;
-  $creds = ding_library_user_get_credentials($user);
-  if ($creds == DING_PROVIDER_AUTH_REQUIRED) {
-    watchdog('alma_user', 'No session in add payment. Transaction: @transaction', array('@transaction' => print_r($transaction, TRUE)), WATCHDOG_EMERG);
-  }
-  else {
-    alma_client_invoke('add_payment', implode(',', $transaction['params']['selected_debts']), $transaction['payment_order_id']);
-  }
+  alma_client_invoke('add_payment', implode(',', $transaction['params']['selected_debts']), $transaction['payment_order_id']);
 }


### PR DESCRIPTION
The addPayment Alma method does not require authentication, so this
check is uneccessary, and might cause problems with expiring sessions,
or using a different session backend than the database.

We were having issues with failed payments due to this check on bibliotek.kk.dk, for reasons we are not quite sure of yet.

However, the system should err on the side of caution here, since any failure in this part of the process results in defrauding the paying customer. Basically, we take his money, but does not mark his bill as paid.

This change also obsoletes all the session juggling code in https://github.com/dingproject/ding/blob/master/ding_dibs/ding_dibs.module#L60, but we should probably wait before removing that, since it currently causes no harm.
