### PR TITLE
Adding user category from librarysystem

### DIFF
--- a/lib/AlmaClient/AlmaClient.class.php
+++ b/lib/AlmaClient/AlmaClient.class.php
@@ -259,6 +259,7 @@ class AlmaClient {
       'addresses' => array(),
       'mails' => array(),
       'phones' => array(),
+      'category' =>  $info->getAttribute('patronCategory'),
     );
 
     foreach ($info->getElementsByTagName('address') as $address) {


### PR DESCRIPTION
This change are required by the new module, ting_ezproxy. 
Ting_ezproxy validate the user to ezproxy and the category from the librarysystem controls which users that are allowed.
